### PR TITLE
Expose Link headers as transitions when using blueprint based Hyperdrive

### DIFF
--- a/Hyperdrive.podspec
+++ b/Hyperdrive.podspec
@@ -13,5 +13,6 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
   spec.dependency 'URITemplate', '~> 1.2'
   spec.dependency 'Representor', '~> 0.6.0'
+  spec.dependency 'WebLinking', '~> 0.2.0'
 end
 

--- a/Hyperdrive/HyperBlueprint.swift
+++ b/Hyperdrive/HyperBlueprint.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Representor
 import URITemplate
+import WebLinking
 
 
 private func flatMap<T, U>(source:[T], transform:(T -> U?)) -> [U] {
@@ -285,6 +286,18 @@ public class HyperBlueprint : Hyperdrive {
           }
 
           self.addTransitions(resource, parameters: parameters, builder: builder, allowedMethods: allowedMethods)
+        }
+
+        for link in response.links {
+          if let relation = link.relationType {
+            builder.addTransition(relation, uri: link.uri) { builder in
+              builder.method = "GET"
+
+              if let type = link.type {
+                builder.suggestedContentTypes = [type]
+              }
+            }
+          }
         }
       }
     }

--- a/HyperdriveTests/HyperBlueprintTests.swift
+++ b/HyperdriveTests/HyperBlueprintTests.swift
@@ -90,4 +90,27 @@ class HyperBlueprintTests: XCTestCase {
 
     XCTAssertTrue(createTransition == nil)
   }
+
+  func testConstructingResponseShowsWebLinkingHeaders() {
+    let attributes = ["question": "Favourite Programming Language?"]
+    let URL = NSURL(string: "https://polls.apiblueprint.org/questions/5")!
+    let request = NSURLRequest(URL: URL)
+    let headers = [
+      "Content-Type": "application/json",
+      "Link": "<https://polls.apiblueprint.org/questions/6>; rel=\"next\", <https://polls.apiblueprint.org/questions/4>; rel=\"prev\"; type=\"foo\"",
+    ]
+    let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: nil, headerFields: headers)!
+    let body = NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(0), error: nil)!
+
+    let representor = hyperdrive.constructResponse(request, response: response, body: body)!
+    let nextTransition = representor.transitions["next"]!
+    let prevTransition = representor.transitions["prev"]!
+
+    XCTAssertEqual(prevTransition.uri, "https://polls.apiblueprint.org/questions/4")
+    XCTAssertEqual(prevTransition.method, "GET")
+    XCTAssertEqual(prevTransition.suggestedContentTypes, ["foo"])
+    XCTAssertEqual(nextTransition.uri, "https://polls.apiblueprint.org/questions/6")
+    XCTAssertEqual(nextTransition.method, "GET")
+    XCTAssertEqual(nextTransition.suggestedContentTypes, [])
+  }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,13 +24,16 @@ PODS:
   - Representor/HTTP/Transition (0.6.0):
     - Representor/Core
   - URITemplate (1.2.0)
+  - WebLinking (0.2.0)
 
 DEPENDENCIES:
   - Representor (~> 0.6.0)
   - URITemplate (~> 1.2)
+  - WebLinking (~> 0.2.0)
 
 SPEC CHECKSUMS:
   Representor: 4e5f5bf36a899e05205f446f23705ed4d8121c29
   URITemplate: 0dbf40f0e378eb9c6d04cc08e6101fb82d126dc3
+  WebLinking: 8e267eed3f7b2d040bf6468681cc1325141ab7fe
 
-COCOAPODS: 0.37.1
+COCOAPODS: 0.38.0.beta.2


### PR DESCRIPTION
This allows a server to add additional transitions, such as a next/previous page via link headers, for example with the link headers in the [polls api](https://github.com/apiaryio/polls-api).