### PR TITLE
Use the Allow header to hide unavailable transitions when using blueprints

### DIFF
--- a/HyperdriveTests/HyperBlueprintTests.swift
+++ b/HyperdriveTests/HyperBlueprintTests.swift
@@ -74,4 +74,20 @@ class HyperBlueprintTests: XCTestCase {
     XCTAssertEqual(createTransition!.uri, "https://polls.apiblueprint.org/questions")
     XCTAssertEqual(createTransition!.method, "POST")
   }
+
+  func testConstructingResponseHidesTransitionsNotIncludedInAllowHeader() {
+    let URL = NSURL(string: "https://polls.apiblueprint.org/questions")!
+    let request = NSURLRequest(URL: URL)
+    let headers = [
+      "Allow": "HEAD, GET",
+      "Content-Type": "application/json",
+    ]
+    let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: nil, headerFields: headers)!
+    let body = NSJSONSerialization.dataWithJSONObject([], options: NSJSONWritingOptions(0), error: nil)!
+
+    let representor = hyperdrive.constructResponse(request, response: response, body: body)!
+    let createTransition = representor.transitions["create"]
+
+    XCTAssertTrue(createTransition == nil)
+  }
 }

--- a/HyperdriveTests/HyperBlueprintTests.swift
+++ b/HyperdriveTests/HyperBlueprintTests.swift
@@ -18,7 +18,8 @@ class HyperBlueprintTests: XCTestCase {
 
   override func setUp() {
     let listAction = Action(name: "List", description: nil, method: "GET", parameters: [], uriTemplate: nil, relation: "questions", examples: nil)
-    let listResource = Resource(name: "Questions", description: nil, uriTemplate: "/questions", parameters: [], actions: [listAction])
+    let createAction = Action(name: "Create", description: nil, method: "POST", parameters: [], uriTemplate: nil, relation: "create", examples: nil)
+    let listResource = Resource(name: "Questions", description: nil, uriTemplate: "/questions", parameters: [], actions: [createAction, listAction])
 
     let viewAction = Action(name: "View", description: nil, method: "GET", parameters: [], uriTemplate: nil, relation: "question", examples: nil)
     let viewResource = Resource(name: "Detail", description: nil, uriTemplate: "/questions/{id}", parameters: [], actions: [viewAction])
@@ -58,5 +59,19 @@ class HyperBlueprintTests: XCTestCase {
     let representor = hyperdrive.constructResponse(request, response: response, body: body)!
 
     XCTAssertEqual(representor.attributes as NSDictionary, attributes)
+  }
+
+  func testConstructingResponseShowsTransitions() {
+    let URL = NSURL(string: "https://polls.apiblueprint.org/questions")!
+    let request = NSURLRequest(URL: URL)
+    let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: nil, headerFields: ["Content-Type": "application/json"])!
+    let body = NSJSONSerialization.dataWithJSONObject([], options: NSJSONWritingOptions(0), error: nil)!
+
+    let representor = hyperdrive.constructResponse(request, response: response, body: body)!
+    let createTransition = representor.transitions["create"]
+
+    XCTAssertTrue(createTransition != nil)
+    XCTAssertEqual(createTransition!.uri, "https://polls.apiblueprint.org/questions")
+    XCTAssertEqual(createTransition!.method, "POST")
   }
 }


### PR DESCRIPTION
This pull request allows the server to indicate that an action in a blueprint may not be available on the server if the action's method is removed from the Allow header.

This goes along with https://github.com/apiaryio/polls-api/pull/32 which adds the Allow header in our example API.