### PR TITLE
Support Swift 2.0 and watchOS

### DIFF
--- a/Hyperdrive.podspec
+++ b/Hyperdrive.podspec
@@ -14,5 +14,6 @@ Pod::Spec.new do |spec|
   spec.dependency 'URITemplate', '~> 1.3'
   spec.dependency 'Representor', '~> 0.7.0'
   spec.dependency 'WebLinking', '~> 1.0.0'
+  spec.dependency 'Result', '~> 0.6-beta.1'
 end
 

--- a/Hyperdrive.podspec
+++ b/Hyperdrive.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |spec|
   spec.source_files = "#{spec.name}/*.swift"
   spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = '10.9'
+  spec.watchos.deployment_target = '2.0'
   spec.requires_arc = true
   spec.dependency 'URITemplate', '~> 1.3'
   spec.dependency 'Representor', '~> 0.7.0'

--- a/Hyperdrive.podspec
+++ b/Hyperdrive.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = '10.9'
   spec.requires_arc = true
-  spec.dependency 'URITemplate', '~> 1.2'
-  spec.dependency 'Representor', '~> 0.6.1'
-  spec.dependency 'WebLinking', '~> 0.2.0'
+  spec.dependency 'URITemplate', '~> 1.3'
+  spec.dependency 'Representor', '~> 0.7.0'
+  spec.dependency 'WebLinking', '~> 1.0.0'
 end
 

--- a/Hyperdrive.xcodeproj/project.pbxproj
+++ b/Hyperdrive.xcodeproj/project.pbxproj
@@ -168,7 +168,6 @@
 				27DCA5201AD57C7700849B15 /* Frameworks */,
 				27DCA5211AD57C7700849B15 /* Headers */,
 				27DCA5221AD57C7700849B15 /* Resources */,
-				734A5F4E7359273DF31C6507 /* Embed Pods Frameworks */,
 				191FBFC099BD48A776447787 /* Copy Pods Resources */,
 			);
 			buildRules = (
@@ -207,6 +206,8 @@
 		27DCA51B1AD57C7700849B15 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = Apiary;
 				TargetAttributes = {
@@ -312,21 +313,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-HyperdriveTests/Pods-HyperdriveTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		734A5F4E7359273DF31C6507 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Hyperdrive/Pods-Hyperdrive-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9B7FAC856D8C40A12F99D333 /* Check Pods Manifest.lock */ = {

--- a/Hyperdrive/Hyperdrive.swift
+++ b/Hyperdrive/Hyperdrive.swift
@@ -45,7 +45,7 @@ func absoluteRepresentor(baseURL:NSURL?)(original:Representor<HTTPTransition>) -
   }
 
   let representors = map(original.representors) { representors in
-    return map(representors, absoluteRepresentor(baseURL))
+    representors.map(absoluteRepresentor(baseURL))
   }
 
   return Representor(transitions: transitions, representors: representors, attributes: original.attributes, metadata: original.metadata)
@@ -95,7 +95,7 @@ public class Hyperdrive {
   let preferredContentTypes:[String]
 
   /** Initialize hyperdrive
-  :param: preferredContentTypes An optional array of the supported content types in order of preference, when this is nil. All types supported by the Representor will be used.
+  - parameter preferredContentTypes: An optional array of the supported content types in order of preference, when this is nil. All types supported by the Representor will be used.
   */
   public init(preferredContentTypes:[String]? = nil) {
     let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
@@ -118,7 +118,7 @@ public class Hyperdrive {
 
     if let URL = NSURL(string: expandedURI) {
       let request = NSMutableURLRequest(URL: URL)
-      request.setValue("; ".join(preferredContentTypes), forHTTPHeaderField: "Accept")
+      request.setValue(preferredContentTypes.joinWithSeparator("; "), forHTTPHeaderField: "Accept")
       return .Success(request)
     }
 
@@ -140,7 +140,7 @@ public class Hyperdrive {
 
   func encodeAttributes(attributes:[String:AnyObject], suggestedContentTypes:[String]) -> NSData? {
     let JSONEncoder = { (attributes:[String:AnyObject]) -> NSData? in
-      return NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(0), error: nil)
+      return try? NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(rawValue: 0))
     }
 
     let encoders:[String:([String:AnyObject] -> NSData?)] = [

--- a/HyperdriveTests/HyperBlueprintTests.swift
+++ b/HyperdriveTests/HyperBlueprintTests.swift
@@ -33,7 +33,7 @@ class HyperBlueprintTests: XCTestCase {
 
   func testRootResourceIncludesGETAction() {
     let representor = hyperdrive.rootRepresentor()
-    XCTAssertEqual(representor.transitions["questions"]!.uri, "https://polls.apiblueprint.org/questions")
+    XCTAssertEqual(representor.transitions["questions"]?.uri, "https://polls.apiblueprint.org/questions")
   }
 
   // MARK:
@@ -54,7 +54,7 @@ class HyperBlueprintTests: XCTestCase {
     let URL = NSURL(string: "https://polls.apiblueprint.org/questions/5")!
     let request = NSURLRequest(URL: URL)
     let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: nil, headerFields: ["Content-Type": "application/json"])!
-    let body = NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(0), error: nil)!
+    let body = try! NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(rawValue: 0))
 
     let representor = hyperdrive.constructResponse(request, response: response, body: body)!
 
@@ -65,7 +65,7 @@ class HyperBlueprintTests: XCTestCase {
     let URL = NSURL(string: "https://polls.apiblueprint.org/questions")!
     let request = NSURLRequest(URL: URL)
     let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: nil, headerFields: ["Content-Type": "application/json"])!
-    let body = NSJSONSerialization.dataWithJSONObject([], options: NSJSONWritingOptions(0), error: nil)!
+    let body = try! NSJSONSerialization.dataWithJSONObject([], options: NSJSONWritingOptions(rawValue: 0))
 
     let representor = hyperdrive.constructResponse(request, response: response, body: body)!
     let createTransition = representor.transitions["create"]
@@ -79,14 +79,14 @@ class HyperBlueprintTests: XCTestCase {
     let URL = NSURL(string: "https://polls.apiblueprint.org/questions")!
     let request = NSURLRequest(URL: URL)
     let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: nil, headerFields: ["Content-Type": "application/json"])!
-    let body = NSJSONSerialization.dataWithJSONObject([], options: NSJSONWritingOptions(0), error: nil)!
+    let body = try! NSJSONSerialization.dataWithJSONObject([], options: NSJSONWritingOptions(rawValue: 0))
 
     let representor = hyperdrive.constructResponse(request, response: response, body: body)!
     let transition = representor.transitions["self"]
 
-    XCTAssertTrue(transition != nil)
-    XCTAssertEqual(transition!.uri, "https://polls.apiblueprint.org/questions")
-    XCTAssertEqual(transition!.method, "GET")
+    XCTAssertNotNil(transition)
+    XCTAssertEqual(transition?.uri, "https://polls.apiblueprint.org/questions")
+    XCTAssertEqual(transition?.method, "GET")
   }
 
   func testConstructingResponseHidesTransitionsNotIncludedInAllowHeader() {
@@ -97,12 +97,12 @@ class HyperBlueprintTests: XCTestCase {
       "Content-Type": "application/json",
     ]
     let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: nil, headerFields: headers)!
-    let body = NSJSONSerialization.dataWithJSONObject([], options: NSJSONWritingOptions(0), error: nil)!
+    let body = try! NSJSONSerialization.dataWithJSONObject([], options: NSJSONWritingOptions(rawValue: 0))
 
     let representor = hyperdrive.constructResponse(request, response: response, body: body)!
     let createTransition = representor.transitions["create"]
 
-    XCTAssertTrue(createTransition == nil)
+    XCTAssertNil(createTransition)
   }
 
   func testConstructingResponseShowsWebLinkingHeaders() {
@@ -114,7 +114,7 @@ class HyperBlueprintTests: XCTestCase {
       "Link": "<https://polls.apiblueprint.org/questions/6>; rel=\"next\", <https://polls.apiblueprint.org/questions/4>; rel=\"prev\"; type=\"foo\"",
     ]
     let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: nil, headerFields: headers)!
-    let body = NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(0), error: nil)!
+    let body = try! NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(rawValue: 0))
 
     let representor = hyperdrive.constructResponse(request, response: response, body: body)!
     let nextTransition = representor.transitions["next"]!

--- a/HyperdriveTests/HyperdriveTests.swift
+++ b/HyperdriveTests/HyperdriveTests.swift
@@ -26,7 +26,7 @@ class HyperdriveTests: XCTestCase {
 
     switch result {
     case .Success(let request):
-      let header = request.allHTTPHeaderFields!["Accept"] as! String
+      let header = request.allHTTPHeaderFields!["Accept"]
       XCTAssertEqual(header, "application/vnd.siren+json; application/hal+json")
     case .Failure(let error):
       XCTFail(error.description)
@@ -39,7 +39,7 @@ class HyperdriveTests: XCTestCase {
 
     switch result {
     case .Success(let request):
-      let header = request.allHTTPHeaderFields!["Accept"] as! String
+      let header = request.allHTTPHeaderFields!["Accept"]
       XCTAssertEqual(header, "application/hal+json")
     case .Failure(let error):
       XCTFail(error.description)
@@ -51,7 +51,7 @@ class HyperdriveTests: XCTestCase {
 
     switch result {
     case .Success(let request):
-      XCTAssertEqual(request.URL!.absoluteString!, "https://hyperdrive-tests.fuller.li/kyle")
+      XCTAssertEqual(request.URL?.absoluteString, "https://hyperdrive-tests.fuller.li/kyle")
     case .Failure(let error):
       XCTFail(error.description)
     }
@@ -65,7 +65,7 @@ class HyperdriveTests: XCTestCase {
 
     switch result {
     case .Success(let request):
-      let header = request.allHTTPHeaderFields!["Accept"] as! String
+      let header = request.allHTTPHeaderFields!["Accept"]
       XCTAssertEqual(header, "application/vnd.siren+json; application/hal+json")
     case .Failure(let error):
       XCTFail(error.description)
@@ -78,7 +78,7 @@ class HyperdriveTests: XCTestCase {
 
     switch result {
     case .Success(let request):
-      XCTAssertEqual(request.URL!.absoluteString!, "https://hyperdrive-tests.fuller.li/kyle")
+      XCTAssertEqual(request.URL?.absoluteString, "https://hyperdrive-tests.fuller.li/kyle")
     case .Failure(let error):
       XCTFail(error.description)
     }
@@ -107,7 +107,7 @@ class HyperdriveTests: XCTestCase {
     switch result {
     case .Success(let request):
       let body = request.HTTPBody!
-      let decodedBody = NSJSONSerialization.JSONObjectWithData(body, options: NSJSONReadingOptions(0), error: nil) as! NSDictionary
+      let decodedBody = try? NSJSONSerialization.JSONObjectWithData(body, options: NSJSONReadingOptions(rawValue: 0)) as! NSDictionary
       XCTAssertEqual(decodedBody, ["username": "kyle"])
     case .Failure(let error):
       XCTFail(error.description)
@@ -129,10 +129,10 @@ class HyperdriveTests: XCTestCase {
         "test": "hello world"
       ]
     ]
-    let body = NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(0), error: nil)!
+    let body = try! NSJSONSerialization.dataWithJSONObject(attributes, options: NSJSONWritingOptions(rawValue: 0))
 
     let representor = hyperdrive.constructResponse(request, response: response, body:body)!
-    XCTAssertEqual(representor.attributes["test"] as! String, "hello world")
+    XCTAssertEqual(representor.attributes["test"] as? String, "hello world")
   }
 }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,16 +23,19 @@ PODS:
     - Representor/HTTP/Transition
   - Representor/HTTP/Transition (0.7.0):
     - Representor/Core
+  - Result (0.6-beta.1)
   - URITemplate (1.3.0)
   - WebLinking (1.0.0)
 
 DEPENDENCIES:
   - Representor (~> 0.7.0)
+  - Result (~> 0.6-beta.1)
   - URITemplate (~> 1.3)
   - WebLinking (~> 1.0.0)
 
 SPEC CHECKSUMS:
   Representor: 487b4efb0a39c2c2db258d40846d9915cd69b770
+  Result: 6c990ec4a72470672f9fc5b6fef009da0f6f40d1
   URITemplate: 0ebbec80d1eb59a89e29db9b14c99d5908d3e574
   WebLinking: d5b5ab4f7305bcf29821deb5cecd775f6c37efae
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,39 +1,39 @@
 PODS:
-  - Representor (0.6.1):
-    - Representor/Core (= 0.6.1)
-    - Representor/HTTP (= 0.6.1)
-  - Representor/Core (0.6.1)
-  - Representor/HTTP (0.6.1):
-    - Representor/HTTP/Adapters (= 0.6.1)
-    - Representor/HTTP/Deserialization (= 0.6.1)
-    - Representor/HTTP/Transition (= 0.6.1)
-  - Representor/HTTP/Adapters (0.6.1):
-    - Representor/HTTP/Adapters/APIBlueprint (= 0.6.1)
-    - Representor/HTTP/Adapters/HAL (= 0.6.1)
-    - Representor/HTTP/Adapters/Siren (= 0.6.1)
-  - Representor/HTTP/Adapters/APIBlueprint (0.6.1):
+  - Representor (0.7.0):
+    - Representor/Core (= 0.7.0)
+    - Representor/HTTP (= 0.7.0)
+  - Representor/Core (0.7.0)
+  - Representor/HTTP (0.7.0):
+    - Representor/HTTP/Adapters (= 0.7.0)
+    - Representor/HTTP/Deserialization (= 0.7.0)
+    - Representor/HTTP/Transition (= 0.7.0)
+  - Representor/HTTP/Adapters (0.7.0):
+    - Representor/HTTP/Adapters/APIBlueprint (= 0.7.0)
+    - Representor/HTTP/Adapters/HAL (= 0.7.0)
+    - Representor/HTTP/Adapters/Siren (= 0.7.0)
+  - Representor/HTTP/Adapters/APIBlueprint (0.7.0):
     - Representor/HTTP/Transition
-  - Representor/HTTP/Adapters/HAL (0.6.1):
+  - Representor/HTTP/Adapters/HAL (0.7.0):
     - Representor/HTTP/Transition
-  - Representor/HTTP/Adapters/Siren (0.6.1):
+  - Representor/HTTP/Adapters/Siren (0.7.0):
     - Representor/HTTP/Transition
-  - Representor/HTTP/Deserialization (0.6.1):
+  - Representor/HTTP/Deserialization (0.7.0):
     - Representor/HTTP/Adapters/HAL
     - Representor/HTTP/Adapters/Siren
     - Representor/HTTP/Transition
-  - Representor/HTTP/Transition (0.6.1):
+  - Representor/HTTP/Transition (0.7.0):
     - Representor/Core
-  - URITemplate (1.2.0)
-  - WebLinking (0.2.0)
+  - URITemplate (1.3.0)
+  - WebLinking (1.0.0)
 
 DEPENDENCIES:
-  - Representor (~> 0.6.1)
-  - URITemplate (~> 1.2)
-  - WebLinking (~> 0.2.0)
+  - Representor (~> 0.7.0)
+  - URITemplate (~> 1.3)
+  - WebLinking (~> 1.0.0)
 
 SPEC CHECKSUMS:
-  Representor: 7675c4253ce7555c46a6f83cf4bba0ad6648994e
-  URITemplate: 0dbf40f0e378eb9c6d04cc08e6101fb82d126dc3
-  WebLinking: 8e267eed3f7b2d040bf6468681cc1325141ab7fe
+  Representor: 487b4efb0a39c2c2db258d40846d9915cd69b770
+  URITemplate: 0ebbec80d1eb59a89e29db9b14c99d5908d3e574
+  WebLinking: d5b5ab4f7305bcf29821deb5cecd775f6c37efae
 
-COCOAPODS: 0.38.0.beta.2
+COCOAPODS: 0.39.0.beta.4


### PR DESCRIPTION
This pull request migrates to Swift 2.0 and adds watchOS support.

I've also pulled out our `Result` type and instead used the `Result` library which provides a cleaner implementation.