### PR TITLE
Accept header content-types should be separated by `,`

### DIFF
--- a/Hyperdrive/Hyperdrive.swift
+++ b/Hyperdrive/Hyperdrive.swift
@@ -94,7 +94,7 @@ public class Hyperdrive {
     let error = NSError(domain: Hyperdrive.errorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Creating NSURL from given URI failed"])
     return Result(NSURL(string: expandedURI), failWith: error).map { URL in
       let request = NSMutableURLRequest(URL: URL)
-      request.setValue(preferredContentTypes.joinWithSeparator("; "), forHTTPHeaderField: "Accept")
+      request.setValue(preferredContentTypes.joinWithSeparator(", "), forHTTPHeaderField: "Accept")
       return request
     }
   }

--- a/HyperdriveTests/HyperdriveTests.swift
+++ b/HyperdriveTests/HyperdriveTests.swift
@@ -27,7 +27,7 @@ class HyperdriveTests: XCTestCase {
     switch result {
     case .Success(let request):
       let header = request.allHTTPHeaderFields!["Accept"]
-      XCTAssertEqual(header, "application/vnd.siren+json; application/hal+json")
+      XCTAssertEqual(header, "application/vnd.siren+json, application/hal+json")
     case .Failure(let error):
       XCTFail(error.description)
     }
@@ -66,7 +66,7 @@ class HyperdriveTests: XCTestCase {
     switch result {
     case .Success(let request):
       let header = request.allHTTPHeaderFields!["Accept"]
-      XCTAssertEqual(header, "application/vnd.siren+json; application/hal+json")
+      XCTAssertEqual(header, "application/vnd.siren+json, application/hal+json")
     case .Failure(let error):
       XCTFail(error.description)
     }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,7 +35,7 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   Representor: 487b4efb0a39c2c2db258d40846d9915cd69b770
-  Result: 6c990ec4a72470672f9fc5b6fef009da0f6f40d1
+  Result: af24e3e57ab81005ec4221a53fd36dc1e7a52869
   URITemplate: 0ebbec80d1eb59a89e29db9b14c99d5908d3e574
   WebLinking: d5b5ab4f7305bcf29821deb5cecd775f6c37efae
 


### PR DESCRIPTION
This was incorrect and instead separated by `;` and not a comma (`,`).