### PR TITLE
Update Result to 1.0.0

### DIFF
--- a/Hyperdrive.podspec
+++ b/Hyperdrive.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
   spec.dependency 'URITemplate', '~> 1.3'
   spec.dependency 'Representor', '~> 0.7.0'
-  spec.dependency 'WebLinking', '~> 1.0.0'
+  spec.dependency 'WebLinking', '~> 1.0'
   spec.dependency 'Result', '~> 1.0'
 end
 

--- a/Hyperdrive.podspec
+++ b/Hyperdrive.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |spec|
   spec.dependency 'URITemplate', '~> 1.3'
   spec.dependency 'Representor', '~> 0.7.0'
   spec.dependency 'WebLinking', '~> 1.0.0'
-  spec.dependency 'Result', '~> 0.6-beta.1'
+  spec.dependency 'Result', '~> 1.0'
 end
 

--- a/Hyperdrive.xcodeproj/project.pbxproj
+++ b/Hyperdrive.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		27DCA5301AD57C7800849B15 /* Hyperdrive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27DCA5241AD57C7700849B15 /* Hyperdrive.framework */; };
 		27DCA5371AD57C7800849B15 /* HyperdriveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27DCA5361AD57C7800849B15 /* HyperdriveTests.swift */; };
 		27DCA5411AD57FFA00849B15 /* Hyperdrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27DCA5401AD57FFA00849B15 /* Hyperdrive.swift */; };
-		C9B3E6FD0D21CF6CAA491ADC /* Pods_HyperdriveTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB9F462C64D2EC3F27D10978 /* Pods_HyperdriveTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		FCE9961D3FDE9C019F699642 /* Pods_Hyperdrive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C39D0C6FBCAF7BC694DC6163 /* Pods_Hyperdrive.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C9B3E6FD0D21CF6CAA491ADC /* Pods_HyperdriveTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB9F462C64D2EC3F27D10978 /* Pods_HyperdriveTests.framework */; };
+		FCE9961D3FDE9C019F699642 /* Pods_Hyperdrive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C39D0C6FBCAF7BC694DC6163 /* Pods_Hyperdrive.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,20 +23,20 @@ PODS:
     - Representor/HTTP/Transition
   - Representor/HTTP/Transition (0.7.0):
     - Representor/Core
-  - Result (0.6-beta.1)
+  - Result (1.0.0)
   - URITemplate (1.3.0)
   - WebLinking (1.0.0)
 
 DEPENDENCIES:
   - Representor (~> 0.7.0)
-  - Result (~> 0.6-beta.1)
+  - Result (~> 1.0)
   - URITemplate (~> 1.3)
   - WebLinking (~> 1.0.0)
 
 SPEC CHECKSUMS:
   Representor: 487b4efb0a39c2c2db258d40846d9915cd69b770
-  Result: af24e3e57ab81005ec4221a53fd36dc1e7a52869
+  Result: feaaff535eb59c414c6c7f95e6145ab991b1b07f
   URITemplate: 0ebbec80d1eb59a89e29db9b14c99d5908d3e574
   WebLinking: d5b5ab4f7305bcf29821deb5cecd775f6c37efae
 
-COCOAPODS: 0.39.0.beta.4
+COCOAPODS: 0.39.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -31,7 +31,7 @@ DEPENDENCIES:
   - Representor (~> 0.7.0)
   - Result (~> 1.0)
   - URITemplate (~> 1.3)
-  - WebLinking (~> 1.0.0)
+  - WebLinking (~> 1.0)
 
 SPEC CHECKSUMS:
   Representor: 487b4efb0a39c2c2db258d40846d9915cd69b770


### PR DESCRIPTION
Result has now hit 1.0.0, so we no longer have to pin to a pre-release. I've also adjusted WebLinking to pin to `~> 1.0` instead of `~> 1.0.0` so that minor releases are unlocked. It was incorrect to pin to `~> 1.0.0`.

There are a few project related changes, this is due to CocoaPods no longer uses weak linking, and thus `settings = {ATTRIBUTES = (Weak, ); };` get's removed from resultant frameworks during `pod install`